### PR TITLE
商品一覧機能の実装

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "editor.minimap.enabled": false
+}

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -125,17 +125,17 @@
     <h2 class='title'>ピックアップカテゴリー</h2>
     <%= link_to '新規投稿商品', new_item_path, class: "subtitle" %>
     <ul class='item-lists'>
-
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+    <% unless @item.present? %>
+      <% @items.each do |item| %>
       <li class='list'>
-        <% @items.each do |item| %>
+        <%= link_to "#" do %>
         <div class='item-img-content'>
-          <%= image_tag item.image, class: "item-img" %>
-
+          <%= image_tag item.image, class: "item-img" if item.image.attached? %>
+  '
           <%# 商品が売れていればsold outの表示 %>
-          <div class='sold-out'>
-            <span>Sold Out!!</span>
-          </div>
+            <%# <div class='sold-out'>
+              <span>Sold Out!!</span>
+            </div> %>
           <%# //商品が売れていればsold outの表示 %>
 
         </div>
@@ -153,8 +153,8 @@
         </div>
         <% end %>
       </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-
+      <% end %>
+    <% else %>
       <%# 商品がない場合のダミー %>
       <%# 商品がある場合は表示されないようにしましょう %>
       <li class='list'>
@@ -176,6 +176,7 @@
       </li>
       <%# //商品がある場合は表示されないようにしましょう %>
       <%# //商品がない場合のダミー %>
+    <% end %>
     </ul>
   </div>
   <%# //商品一覧 %>


### PR DESCRIPTION
#what
出品された商品がindexページで一覧表示される機能
画像、名前、価格がセットで表示されている
（rubocop済みです）
#why
フリマアプリのトップページ作成のため
